### PR TITLE
Fix scheduler multistep gamma argument

### DIFF
--- a/libs/utils/train_utils.py
+++ b/libs/utils/train_utils.py
@@ -180,7 +180,7 @@ def make_scheduler(
             scheduler = optim.lr_scheduler.MultiStepLR(
                 optimizer,
                 steps,
-                gamma=schedule_config["gamma"],
+                gamma=optimizer_config["schedule_gamma"],
                 last_epoch=last_epoch
             )
         else:


### PR DESCRIPTION
## Summary
- fix scheduler variable name in `make_scheduler`

## Testing
- `python -m py_compile libs/utils/train_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684d2b1d95c88330971f8d649e34d78a